### PR TITLE
Update for Xcode 9 compatibility

### DIFF
--- a/src/Xcode.swift
+++ b/src/Xcode.swift
@@ -1,6 +1,6 @@
 class Xcode {
 
-    static let requiredVersion = "Xcode 8"
+    static let requiredVersion = "Xcode 9"
 
     static func isRequiredVersionInstalled() -> Bool {
         guard let currentVersion = Xcode.currentVersion() else { return false }


### PR DESCRIPTION
Make the Xcode required version 9.0 so simulator builds will work with recent iOS simulators