### PR TITLE
Update for Xcode 10 compatibility

### DIFF
--- a/src/Xcode.swift
+++ b/src/Xcode.swift
@@ -1,6 +1,6 @@
 class Xcode {
 
-    static let requiredVersion = "Xcode 9"
+    static let requiredVersion = "Xcode 10"
 
     static func isRequiredVersionInstalled() -> Bool {
         guard let currentVersion = Xcode.currentVersion() else { return false }


### PR DESCRIPTION
Make the Xcode required version 10 so simulator builds will work with recent iOS simulators